### PR TITLE
Remove current instance version string from status panel

### DIFF
--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -109,7 +109,6 @@ namespace CKAN
             this.ManageModsTabPage = new System.Windows.Forms.TabPage();
             this.FilterByAuthorTextBox = new HintTextBox();
             this.FilterByAuthorLabel = new System.Windows.Forms.Label();
-            this.KSPVersionLabel = new System.Windows.Forms.Label();
             this.FilterByNameLabel = new System.Windows.Forms.Label();
             this.FilterByNameTextBox = new HintTextBox();
             this.FilterByDescriptionLabel = new System.Windows.Forms.Label();
@@ -984,7 +983,6 @@ namespace CKAN
             // 
             this.StatusPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.StatusPanel.Controls.Add(this.StatusLabel);
-            this.StatusPanel.Controls.Add(this.KSPVersionLabel);
             this.StatusPanel.Location = new System.Drawing.Point(0, 1074);
             this.StatusPanel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.StatusPanel.Name = "StatusPanel";
@@ -1000,17 +998,6 @@ namespace CKAN
             this.StatusLabel.Size = new System.Drawing.Size(1050, 29);
             this.StatusLabel.TabIndex = 0;
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // KSPVersionLabel
-            // 
-            this.KSPVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.KSPVersionLabel.AutoSize = true;
-            this.KSPVersionLabel.Location = new System.Drawing.Point(1280, 15);
-            this.KSPVersionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.KSPVersionLabel.Name = "KSPVersionLabel";
-            this.KSPVersionLabel.Size = new System.Drawing.Size(230, 29);
-            this.KSPVersionLabel.TabIndex = 1;
-            this.KSPVersionLabel.Text = "Kerbal Space Program 0.25.0";
             // 
             // MainTabControl
             // 
@@ -1546,7 +1533,6 @@ namespace CKAN
         private ToolStripMenuItem launchKSPToolStripMenuItem;
         private CKAN.MainTabControl MainTabControl;
         private TabPage ManageModsTabPage;
-        private Label KSPVersionLabel;
         private Label FilterByNameLabel;
         private HintTextBox FilterByNameTextBox;
         private Label FilterByDescriptionLabel;

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -358,7 +358,6 @@ namespace CKAN
 
             Text = String.Format("CKAN {0} - KSP {1}  --  {2}", Meta.Version(), CurrentInstance.Version(),
                 CurrentInstance.GameDir());
-            KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
 
             if (commandLineArgs.Length >= 2)
             {
@@ -429,7 +428,6 @@ namespace CKAN
             {
                 Text = String.Format("CKAN {0} - KSP {1}    --    {2}", Meta.Version(), CurrentInstance.Version(),
                 CurrentInstance.GameDir());
-                KSPVersionLabel.Text = String.Format("Kerbal Space Program {0}", CurrentInstance.Version());
             });
 
             configuration = Configuration.LoadOrCreateConfiguration


### PR DESCRIPTION
This removes the KSP Version Label control from the main form entirely, which saves space and does not give the user any less information.
