### PR TITLE
Fix/test csproj replacedby

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -50,7 +50,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\_build\lib\nuget\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>


### PR DESCRIPTION
I think this is the cause of the tests failing - the `<Private>False</Private>` tag prevents the reference's DLL from being copied to the output folder, so it's not available when the tests are run. The tests succeed again for me with this change.