### PR TITLE
Support replaced_by in ConsoleUI

### DIFF
--- a/ConsoleUI/DependencyScreen.cs
+++ b/ConsoleUI/DependencyScreen.cs
@@ -31,6 +31,7 @@ namespace CKAN.ConsoleUI {
             ));
 
             generateList(plan.Install);
+            generateList(new HashSet<string>(ReplacementIdentifiers(plan.Replace)));
 
             dependencyList = new ConsoleListBox<Dependency>(
                 1, 4, -1, -2,
@@ -133,6 +134,18 @@ namespace CKAN.ConsoleUI {
                 if (m != null) {
                     AddDependencies(inst, mod, m.recommends, true);
                     AddDependencies(inst, mod, m.suggests,   false);
+                }
+            }
+        }
+
+        private IEnumerable<string> ReplacementIdentifiers(IEnumerable<string> replaced_identifiers)
+        {
+            foreach (string replaced in replaced_identifiers) {
+                ModuleReplacement repl = registry.GetReplacement(
+                    replaced, manager.CurrentInstance.VersionCriteria()
+                );
+                if (repl != null) {
+                    yield return repl.ReplaceWith.identifier;
                 }
             }
         }

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -71,6 +71,10 @@ namespace CKAN.ConsoleUI {
                             inst.InstallList(iList, resolvOpts, dl);
                             plan.Install.Clear();
                         }
+                        if (plan.Replace.Count > 0) {
+                            inst.Replace(AllReplacements(plan.Replace), resolvOpts, dl, true);
+                        }
+
                         trans.Complete();
                         // Don't let the installer re-use old screen references
                         inst.User = null;
@@ -134,6 +138,20 @@ namespace CKAN.ConsoleUI {
         private void OnModInstalled(CkanModule mod)
         {
             RaiseMessage($"{Symbols.checkmark} Successfully installed {mod.name} {Formatting.StripEpoch(mod.version)}");
+        }
+
+        private IEnumerable<ModuleReplacement> AllReplacements(IEnumerable<string> identifiers)
+        {
+            IRegistryQuerier registry = RegistryManager.Instance(manager.CurrentInstance).registry;
+
+            foreach (string id in identifiers) {
+                ModuleReplacement repl = registry.GetReplacement(
+                    id, manager.CurrentInstance.VersionCriteria()
+                );
+                if (repl != null) {
+                    yield return repl;
+                }
+            }
         }
 
         private static readonly RelationshipResolverOptions resolvOpts = new RelationshipResolverOptions() {

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -299,14 +299,45 @@ namespace CKAN.ConsoleUI {
 
                     if (latestIsInstalled) {
 
-                        addVersionBox(
-                            boxLeft, boxTop, boxRight, boxTop + boxH - 1,
-                            () => $"Latest/Installed {instTime.ToString("d")}",
-                            () => ConsoleTheme.Current.ActiveFrameFg,
-                            true,
-                            new List<CkanModule>() {inst}
+                        ModuleReplacement mr = registry.GetReplacement(
+                            mod.identifier,
+                            manager.CurrentInstance.VersionCriteria()
                         );
-                        boxTop += boxH;
+
+                        if (mr != null) {
+
+                            // Show replaced_by
+                            addVersionBox(
+                                boxLeft, boxTop, boxRight, boxTop + boxH - 1,
+                                () => $"Replaced by {mr.ReplaceWith.identifier}",
+                                () => ConsoleTheme.Current.AlertFrameFg,
+                                false,
+                                new List<CkanModule>() {mr.ReplaceWith}
+                            );
+                            boxTop += boxH;
+
+                            addVersionBox(
+                                boxLeft, boxTop, boxRight, boxTop + boxH - 1,
+                                () => $"Installed {instTime.ToString("d")}",
+                                () => ConsoleTheme.Current.ActiveFrameFg,
+                                true,
+                                new List<CkanModule>() {inst}
+                            );
+                            boxTop += boxH;
+
+                        } else {
+
+                            addVersionBox(
+                                boxLeft, boxTop, boxRight, boxTop + boxH - 1,
+                                () => $"Latest/Installed {instTime.ToString("d")}",
+                                () => ConsoleTheme.Current.ActiveFrameFg,
+                                true,
+                                new List<CkanModule>() {inst}
+                            );
+                            boxTop += boxH;
+
+                        }
+
 
                     } else {
 

--- a/ConsoleUI/ModListHelpDialog.cs
+++ b/ConsoleUI/ModListHelpDialog.cs
@@ -14,7 +14,7 @@ namespace CKAN.ConsoleUI {
         /// </summary>
         public ModListHelpDialog() : base()
         {
-            SetDimensions(9, 4, -9, -3);
+            SetDimensions(9, 3, -9, -3);
 
             int btnW = 10;
             int btnL = (Console.WindowWidth - btnW) / 2;
@@ -31,6 +31,7 @@ namespace CKAN.ConsoleUI {
             symbolTb.AddLine("==============");
             symbolTb.AddLine($"{installed}    Installed");
             symbolTb.AddLine($"{upgradable}  Upgradeable");
+            symbolTb.AddLine($"{replaceable}  Replaceable");
             symbolTb.AddLine($"!  Unavailable");
             symbolTb.AddLine(" ");
             symbolTb.AddLine("Basic Keys");
@@ -65,6 +66,7 @@ namespace CKAN.ConsoleUI {
 
         private static readonly string installed    = Symbols.checkmark;
         private static readonly string upgradable   = Symbols.greaterEquals;
+        private static readonly string replaceable  = Symbols.doubleGreater;
     }
 
 }

--- a/ConsoleUI/Toolkit/Symbols.cs
+++ b/ConsoleUI/Toolkit/Symbols.cs
@@ -26,6 +26,15 @@ namespace CKAN.ConsoleUI.Toolkit {
         /// >= symbol
         /// </summary>
         public static readonly string greaterEquals    = cp437s(0xf2);
+        /// <summary>
+        /// +- symbol
+        /// </summary>
+        public static readonly string plusMinus        = cp437s(0xf1);
+        /// <summary>
+        /// >> symbol
+        /// </summary>
+        public static readonly string doubleGreater    = cp437s(0xaf);
+
 
         /// <summary>
         /// Hashed square box for drawing scrollbars


### PR DESCRIPTION
KSP-CKAN/CKAN#1888 is creating a `replaced_by` feature. Since it was developed in parallel with KSP-CKAN/CKAN#2177, it only supports Cmdline and GUI.

This pull request adds support for ConsoleUI.